### PR TITLE
Upgrade dependent libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8 # Use oraclejdk8 because checkstyle jar is compiled by jdk8 but, released plugin is still built by oraclejdk7.
+jdk: openjdk8
 script:
 - ./gradlew --info check
 after_success:

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,10 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.29"
-    provided "org.embulk:embulk-core:0.8.29"
-    compile  "org.embulk:embulk-standards:0.8.29"
-    provided "org.embulk:embulk-standards:0.8.29"
+    compile  "org.embulk:embulk-core:0.9.18"
+    provided "org.embulk:embulk-core:0.9.18"
+    compile  "org.embulk:embulk-standards:0.9.18"
+    provided "org.embulk:embulk-standards:0.9.18"
     compile  "com.treasuredata.client:td-client:0.9.0"
 
     testCompile "junit:junit:4.+"

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ configurations {
 
 version = "0.2.1"
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     compile  "org.embulk:embulk-core:0.9.18"

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     provided "org.embulk:embulk-core:0.8.29"
     compile  "org.embulk:embulk-standards:0.8.29"
     provided "org.embulk:embulk-standards:0.8.29"
-    compile  "com.treasuredata.client:td-client:0.7.41"
+    compile  "com.treasuredata.client:td-client:0.9.0"
 
     testCompile "junit:junit:4.+"
 }


### PR DESCRIPTION
* Upgrade td-client-java from 0.7.41 to 0.9.0
  td-client-java is dynamically improved stability/error handling since 0.8.x this may solve #21 
* Upgrade Embulk version from 0.8.29 to 0.9.18
* Upgrade Java version to Java8 (Embulk v0.9.x no longer supports Java7)
  * Use OpenJDK8 instead of OracleJDK8 because CI failure happened while installing OpenJDK
    https://travis-ci.org/muga/embulk-input-td/builds/574189147